### PR TITLE
Some fixes

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,6 +17,10 @@ promote:
 
 github:
   delete_branch_on_merge: true
+  minor_bump_labels:
+    - "Expeditor: Bump Version Minor"
+  major_bump_labels:
+    - "Expeditor: Bump Version Major"
   release_branch:
     - main
 

--- a/commands/configure_accounts.go
+++ b/commands/configure_accounts.go
@@ -40,6 +40,10 @@ func configureAccountsE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	defer func() {
+		_ = lock.Unlock()
+	}()
+
 	retryErr := retry.Do(
 		func() error {
 			_, lockErr := lock.TryLock()
@@ -55,11 +59,6 @@ func configureAccountsE(cmd *cobra.Command, args []string) error {
 			configErr := configureAccounts(accountsJSON)
 			if configErr != nil {
 				return errors.Wrap(configErr, "failed to configure accounts")
-			}
-
-			unlockErr := lock.Unlock()
-			if unlockErr != nil {
-				return errors.Wrap(unlockErr, "failed to release account configuration lock")
 			}
 
 			return nil

--- a/commands/configure_accounts_test.go
+++ b/commands/configure_accounts_test.go
@@ -223,7 +223,7 @@ func TestConfigureAccountsE(t *testing.T) {
 		assert.Equal(t, "aws configure set aws_access_key_id fake-access-key-id --profile my-account", configureCommands[0])
 		assert.Equal(t, "aws configure set aws_secret_access_key fake-secret-access-key+ --profile my-account", configureCommands[1])
 		assert.Equal(t, "aws configure set aws_session_token fake-secret-token --profile my-account", configureCommands[2])
-		assert.Equal(t, "aws configure set region us-east-1 --profile my-account", configureCommands[3])
+		assert.Equal(t, "aws configure set region us-west-2 --profile my-account", configureCommands[3])
 
 		os.Unsetenv("VAULT_UTIL_ACCOUNTS")
 		output.Reset()

--- a/commands/root.go
+++ b/commands/root.go
@@ -39,7 +39,7 @@ var (
 // Execute handles the execution of child commands and flags.
 func Execute() {
 	var err error
-	var retryAttempts uint = 5
+	var retryAttempts uint = 10
 	var retryDelay time.Duration = 100
 
 	fs = filesystem.NewOsFs()

--- a/commands/root.go
+++ b/commands/root.go
@@ -67,33 +67,15 @@ func init() {
 
 	cobra.OnInitialize(initConfig)
 
-	viper.SetDefault("aws.region", "us-east-1")
+	viper.SetDefault("aws.region", "us-west-2")
 	viper.SetDefault("vault.dynamic_mount", "account/dynamic")
 	viper.SetDefault("vault.static_mount", "account/static")
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	// Override our config with any matching environment variables
-	viper.AutomaticEnv()
-
 	// Set environment variable prefix, eg: VAULT_UTIL_AWS_REGION
 	viper.SetEnvPrefix("vault_util")
-
-	// Load the config file
-	settingsFile := ciutils.SettingsPath("vault-util.toml")
-	settingsFileExists, err := fs.Exists(settingsFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if settingsFileExists {
-		viper.SetConfigFile(settingsFile)
-
-		if err := viper.ReadInConfig(); err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	// Override our config with any matching environment variables
 	viper.AutomaticEnv()

--- a/internal/pkg/install/install_unix.go
+++ b/internal/pkg/install/install_unix.go
@@ -6,7 +6,7 @@ package install
 const DefaultRootParentDir string = "/opt"
 
 // DefaultSettingsDir - default dir for settings.
-const DefaultSettingsDir string = "/var/opt/ci-utils"
+const DefaultSettingsDir string = "/var/opt/ci-settings"
 
 // binName returns the name of binary based on the OS.
 func binName(binary string) string {

--- a/internal/pkg/secrets/account.go
+++ b/internal/pkg/secrets/account.go
@@ -33,6 +33,7 @@ func (c *VaultClient) newAwsAccount(name string) (*Account, error) {
 	data["access_key_id"] = secret.Data["access_key"].(string)
 	data["secret_access_key"] = secret.Data["secret_key"].(string)
 	data["session_token"] = secret.Data["security_token"].(string)
+	data["region"] = viper.GetString("aws.region")
 
 	return &Account{
 		ID:   "aws/" + name,


### PR DESCRIPTION
Use ci-settings directory name for consistency across platforms.

Remove code for vault-util.toml config file and set aws.region default to us-west-2.
We no longer want to set defaults via the vault-util.toml file.

Add aws.region to data returned from newAwsAccount.

Bump retryAttempts to 10
This matches what older versions of vault-util used and provides more time for configure-accounts lock to be released when multiple vault-util instances are run concurrently.

Defer configure-accounts unlock.