### PR TITLE
Build for darwin/arm64

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -10,10 +10,9 @@ pipelines:
       public: true
   - go/build
 
-promote:
-  channels:
-    - unstable
-    - stable
+artifact_channels:
+  - unstable
+  - stable
 
 github:
   delete_branch_on_merge: true

--- a/.expeditor/create_release.sh
+++ b/.expeditor/create_release.sh
@@ -8,7 +8,7 @@ files=()
 function download_artifacts {
   os=$1
   arch=$2
-  
+
   echo "--- Artifactory download vault-util binaries for ${os} ${arch}"
   jfrog rt dl \
   --apikey="${art_token}" \
@@ -35,7 +35,9 @@ function download_artifacts {
 }
 
 download_artifacts linux amd64
+download_artifacts linux arm64
 download_artifacts darwin amd64
+download_artifacts darwin arm64
 download_artifacts windows amd64
 
 notes=$(sed -n -E '/<!-- latest_release (.+) -->|<!-- latest_release -->/,/<!-- latest_release -->/p' CHANGELOG.md)

--- a/.expeditor/go_build.pipeline.yml
+++ b/.expeditor/go_build.pipeline.yml
@@ -1,24 +1,27 @@
 steps:
   - label: ":go: build"
-    command: 
-      - goreleaser build --rm-dist --skip-validate
-      - tar -czf vault-util.tar.gz dist/
-      - buildkite-agent artifact upload "vault-util.tar.gz"
-    expeditor:
-      executor:
-        docker:
+    command: build --rm-dist --skip-validate
+    plugins:
+      - docker#v3.7.0:
+          image: goreleaser/goreleaser
+          always-pull: true
+          shell: false
+      - artifacts#v1.3.0:
+          upload: dist/**/*
 
   - wait
 
   - label: ":artifactory: upload"
-    command: 
-      - buildkite-agent artifact download "vault-util.tar.gz" .
-      - tar -xzf vault-util.tar.gz
-      - .expeditor/artifact_upload.sh
+    command: .expeditor/artifact_upload.sh
     expeditor:
       secrets:
         ARTIFACTORY_TOKEN:
           path: account/static/artifactory/buildkite
           field: token
-      executor:
-        docker:
+    plugins:
+      - artifacts#v1.3.0:
+          download: dist/**/*
+      - docker#v3.7.0:
+          image: chefes/buildkite
+          environment:
+            - ARTIFACTORY_TOKEN

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,3 +15,4 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64


### PR DESCRIPTION
This also updates the build pipeline pattern to avoid using the chefes/buildkite image for building.
