### PR TITLE
Use the new --target-props CLI option

### DIFF
--- a/.expeditor/artifact_upload.sh
+++ b/.expeditor/artifact_upload.sh
@@ -24,7 +24,7 @@ do
   jfrog rt u \
   --apikey="${ARTIFACTORY_TOKEN}" \
   --url=https://artifactory.chef.co/artifactory \
-  --props "project=${util_name};version=${version};os=${os};arch=${arch}" \
+  --target-props "project=${util_name};version=${version};os=${os};arch=${arch}" \
   "${file}" \
   "go-binaries-local/${util_name}/${version}/${os}/${arch}/${binary}"
 done


### PR DESCRIPTION
Got this from the Jfrog CLI

```
[Warn] The --props command option and the 'Props' File Spec property are deprecated in Upload.
--
  | Please use the --target-props command option or the 'targetProps' File Spec property instead.
  | To avoid this message in the future, set the JFROG_CLI_OFFER_CONFIG environment variable to false.
  | The CLI commands require the Artifactory URL and authentication details
  | Configuring JFrog CLI with these parameters now will save you having to include them as command options.
  | You can also configure these parameters later using the 'jfrog rt c' command.
```
